### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#DC3-MWCP
+# DC3-MWCP
 DC3 Malware Configuration Parser (DC3-MWCP) is a framework for parsing configuration information from malware.
 The information extracted from malware includes items such as addresses, passwords, filenames, and
 mutex names. A parser module is usually created per malware family.
@@ -7,27 +7,27 @@ and facilitate parser sharing. DC3-MWCP supports both analyst directed analysis 
 large-scale automated execution, utilizing either the native python API, a REST API, or a provided
 command line tool. DC3-MWCP is authored by the Defense Cyber Crime Center (DC3).
 
-##Dependencies
+## Dependencies
 
 DC3-MWCP requires python 2.7 (the core components should operate on python 2.6).
 
 `mwcp-client.py` requires the requests module.
 
-###Recommended Modules
+### Recommended Modules
 The following modules are recommended as they are often used in parsers
 - pefile
 - yara-python
 - pyCrypto
 - pydasm
 
-##Installation
+## Installation
 
 Use setup.py to perform a setuptools install or build a distributable package. For 
 example, download the source tree and run `setup.py install`.
 
 DC3-MWCP can also be used by merely downloading the source tree and executing the mwcp utilities.
 
-###Parser and Resource installation
+### Parser and Resource installation
 
 Both parsers and external resources (dependencies) are installed separately from DC3-MWCP.
 
@@ -47,7 +47,7 @@ can simply be placed in these directories.
 It is recommended that parser modules be shared in their own distribution packages, allowing for either
 a setup.py install or manual installation by users.
 
-###Updates
+### Updates
 
 DC3-MWCP code updates are implemented to be backwards compatible. 
 
@@ -59,7 +59,7 @@ passing test cases to fail. To resolve this issue, work in an evironment where p
 good state and run the command `mwcp-test.py -ua` to update all test cases. The newly generated test
 cases will include the updated field values.
 
-##Schema
+## Schema
 
 One of the major goals of DC3-MWCP is to standardize output for malware configuration parsers, making the data
 from one parser comparable with that of other parsers. This is achieved by establishing a schema of 
@@ -79,7 +79,7 @@ will be extracted automatically by DC3-MWCP.
 See mwcp/resources/fields.txt for additional explanation.
 
 
-##Use
+## Use
 DC3-MWCP is designed to allow easy development and use of malware config parsers. DC3-MWCP is also designed to ensure
 that these parsers are scalable and that DC3-MWCP can be integrated in other systems.
 
@@ -93,7 +93,7 @@ There are 3 options for integration of DC3-MWCP:
 
 DC3-MWCP also includes a utility for test case generation and execution: mwcp-test.py
 
-###Python API
+### Python API
 
 mwcp_api_example.py demonstrates how to use the python API:
 
@@ -135,7 +135,7 @@ for filename in reporter.outputfiles:
 
 ```
 
-###REST API
+### REST API
 
 The REST API provides two commonly used functions:
 
@@ -151,7 +151,7 @@ curl http://localhost:8080/descriptions
 bottle (bottlepy.org) is required for the server. The bottle provided web server
 or another wsgi can be used.
 
-###CLI tool
+### CLI tool
 
 mwcp-tool.py provides functionality to run parsers on files:
 
@@ -162,7 +162,7 @@ mwcp-tool.py -p foo README.md
 see ```mwcp-tool.py -h``` for full set of options
 
 
-##Parser Development
+## Parser Development
 
 The high level setps for module development are:
 
@@ -216,7 +216,7 @@ class Foo(malwareconfigparser):
 
 ```
 
-###Parser Development Tips
+### Parser Development Tips
 - Standardized field mapping:
   - Let data type dictate field selection
   - Use most complete field possible
@@ -230,7 +230,7 @@ class Foo(malwareconfigparser):
   - Maintain cross platform functionality: *nix and windows
 - Do not use parser arguments unless absolutely necessary
 
-###Tech Anarchy Bridge
+### Tech Anarchy Bridge
 
 While DC3-MWCP does not include any malware parsers, it does include a bridge to enable use
 of the parsers provided by Kev of techanarchy.net/malwareconfig.com. The purpose

--- a/mwcp/resources/enstructured.md
+++ b/mwcp/resources/enstructured.md
@@ -1,4 +1,4 @@
-#Enstructured
+# Enstructured
 enstructured is a library for parsing data. It facilitates parsing based on
 struct-like data format specifications but adds capabilities such as:
 
@@ -11,14 +11,14 @@ enstructured is designed to make re-use of specifications easy.
 
 See enstructured_example.py for an example of parsing a PE header. Examples from this file (denoted by comments) are referenced throughout this document.
 
-##Use
+## Use
 
 enstructured is focused around data specifications. Each member in a specification is a tuple of a core data type, a name (which must be unique in the specification), and optional parameters. Some parameters are universally applicable and some only apply to specific data types. See Example 1. 
 
 Data is extracted from a buffer by creating an Extractor object and running extract members. 
 This returns a dictionary containing all the extracted members. See Example 7.
 
-###Members dictionary
+### Members dictionary
 
 The core output of the enstructured library is a members dictionary, which contains the extracted specification members. The keys in this dictionary are the names used in the specification. 
 For example, given the PE_HEADER example specification, where the first member is:
@@ -60,7 +60,7 @@ location and offset are different. Location is based on the start of the input b
 This distinction is important when structures are applied to a buffer at any location other than 0. This happens often when subfields
 are employed. 
 
-###Member data types
+### Member data types
 
 Enstructured provides a few core data types that can be used to build specifications.
 
@@ -68,24 +68,24 @@ The data types can be discovered by viewing the pydoc for enstructured. The Extr
 For example, extract_unit32() implements the uint32 data type. This data type is aliased with the constants DWORD, ULONG, and UINT32.
 Most of the meanings of these data types are self explanatory. These function definitions also document the data type specific parameters used for extraction.
 
-####Numbers
+#### Numbers
 The numerical data types are the most common and are straightforward. The returned value is a Number, i.e. an integer or a float.
 
-####Strings
+#### Strings
 
 String types are also used widely. String types are organized primarily by the width of the string. Ex. STR or STR8 for 8 bit strings, WCSTR or STR16 for 16 bit strings, and STR32 for 32 bit strings. 
 The default encodings are utf8, utf16, and utf32 respectively but this can be overridden with the encoding parameter. If length isn't specified, the extractor assumes null termination and searches until
 the appropriate null terminator is found. If length is specified it is used. In either case, null padding is removed from the end of the string. The string is returned
 as a unicode object.
 
-####RAW and BYTES
+#### RAW and BYTES
 The bytes types, aliased with RAW and BYTES, is useful for extracting raw binary blobs. The length of the data is almost always specified. This type is often used with formatters and can result in values that aren't printable.
 
-####REGEX
+#### REGEX
 The regex type is used to apply regular expressions, whether for searching, capture, or both. The regex parameter should be a compiled regex object, ex. created by re.compile().
 The location parameter specifies where the regex search starts. If a match is made, the location and length of the member are set to that of the match and the value is the raw data matched.
 
-####SUBFIELDS
+#### SUBFIELDS
 
 The subfield types, subfield, subfieldlist, and mapsubfield allow the nesting of enstructured definitions. 
 
@@ -100,12 +100,12 @@ This type provides arbitrary conditional capability in enstructured specificatio
 A simple binary conditional (if statement) is created by using a map with keys of TRUE or FALSE and an evaluated statement that is used as the parameter key.
 See Example 5 where a mapped subfield is used to select between the 32-bit or 64-bit version of the same structure.
 
-####NULL
+#### NULL
 
 The null data type does not extract any data from the buffer. It simply provides a placeholder for arbitrary operations. It takes a value parameter which is almost invariably an evaluated dynamic value.
 This type is useful for situations where arbitrary operations need to be performed and it is desirable for these to be reported as a member value.
 
-###Parameters
+### Parameters
 
 Enstructured specifications support parameters for each member. Some of these parameters are global, applying to all data types, while some are specific data types. 
 Parameters can include values that run through the eval() function to allow dynamic specifications.
@@ -116,11 +116,11 @@ data type specific parameters are defined in the function definition of the extr
 
 The following parameters are broadly applicable parameters:
 
-####Offset
+#### Offset
 
 The offset parameter can be provided to specify the location where a member resides, relative to the start of the structure. 
 
-####Location
+#### Location
 
 The location parameter can be provided to specify the location where a member resides,
 relative to the start of the input buffer. 
@@ -128,19 +128,19 @@ Typically, offset should be used instead of location as it allows for relative l
 based on the structure location, but location may be used when it is important to use the
 absolute location in the data buffer.
 
-####Skip
+#### Skip
 
 skip tells the parser to advance the specified number of bytes from the end of the last member before starting the current member.
 
-####Length
+#### Length
 
 A large number of types support a length parameter which is specified in bytes.
 
-####Description
+#### Description
 
 The description parameter is simply passed through to the description element of the member dictionary. It is intended to be used for explanations of the meaning of the member beyond that provided by the name.
 
-###Formattters
+### Formattters
 
 All members may have a formatter parameter which is a function used to format the extracted value. 
 This function should accept a parameter which is the extracted value and should return a new value.
@@ -150,14 +150,14 @@ collection of other members (ex. subfield is used).
 
 Enstructured provides some simple formatters and factories for formatters. See Example 4 where a formatter is used transform a unix timestamp from a uint32 to a isoformat datetime string and an enum factory is used.
 
-###Dynamic Parameters using eval()
+### Dynamic Parameters using eval()
 
 To permit dynamic structure definitions, including specifications where members rely on values extracted previously, all parameters can be evaluated using the eval() capability.
 To enable eval() of a parameter, it must be a string that starts and ends with ticks "`". The contents of the string (sans the outer ticks) are run through eval() and that paramter is set to the result of the evaluation.
 
 See Example 3 where the value of a previous member is used to set the location of another member.
 
-####Variables available during parameter eval()
+#### Variables available during parameter eval()
 The following variables are available during parameter evaluation:
 
 - members: the current members dictionary


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
