### PR TITLE
Fixed bug where pefileutils.obtain_export_list contains null entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- `pefileutils.obtain_export_list` would contain a `null` entry as the last item in the list for any file
 
 ## [2.1.0] - 2019-09-10
 

--- a/mwcp/utils/pefileutils.py
+++ b/mwcp/utils/pefileutils.py
@@ -170,7 +170,7 @@ def obtain_exports_list(pe=None, file_data=None):
         pe = obtain_pe(file_data)
     if pe:
         try:
-            return [export.name for export in pe.DIRECTORY_ENTRY_EXPORT.symbols]
+            return [export.name for export in pe.DIRECTORY_ENTRY_EXPORT.symbols if export.name]
         except AttributeError:
             return []
     else:


### PR DESCRIPTION
Fixed situation in pefileutils.obtain_export_list where the last entry for any file would always be null