### PR TITLE
Update windows_structures in construct extension utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - 2020-06-26
 
+### Changed
+- Updated `IMAGE_OPTIONAL_HEADER` to support 64-bit and added missing `DllCharacteristics` Flags. (@ddash-ct)
+- Updated `IMAGE_FILE_HEADER.SizeOfOptionalHeader` to enable leveraging `sizeof()`. (@ddash-ct)
+
 ### Fixed
--	Fixed glob pattern in Techanarchy wrapper. (@cccs-aa)
+- Fixed glob pattern in Techanarchy wrapper. (@cccs-aa)
+- Fixed misspelling of "Characteristics" in `IMAGE_IMPORT_DESCRIPTOR`. (@ddash-ct)
     
 ## [3.1.0] - 2020-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - 2020-06-26
+## [Unreleased]
 
 ### Changed
 - Updated `IMAGE_OPTIONAL_HEADER` to support 64-bit and added missing `DllCharacteristics` Flags. (@ddash-ct)

--- a/mwcp/utils/construct/windows_structures.py
+++ b/mwcp/utils/construct/windows_structures.py
@@ -109,7 +109,7 @@ IMAGE_EXPORT_DIRECTORY = construct.Struct(
 )
 
 IMAGE_IMPORT_DESCRIPTOR = construct.Struct(
-    "Chracteristics" / construct.Int32ul,
+    "Characteristics" / construct.Int32ul,
     "TimeDateStamp" / construct.Int32ul,
     "ForwarderChain" / construct.Int32ul,
     "Name" / construct.Int32ul,  # rva pointer to the name

--- a/mwcp/utils/construct/windows_structures.py
+++ b/mwcp/utils/construct/windows_structures.py
@@ -126,7 +126,7 @@ IMAGE_OPTIONAL_HEADER = construct.Struct(
     "SizeOfUninitializedData" / construct.Int32ul,
     "AddressOfEntryPoint" / construct.Int32ul,
     "BaseOfCode" / construct.Int32ul,
-    "BaseOfData" / construct.If(this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul),
+    "BaseOfData" / construct.If(this.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int32ul),
     "ImageBase" / construct.IfThenElse(
         this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),

--- a/mwcp/utils/construct/windows_structures.py
+++ b/mwcp/utils/construct/windows_structures.py
@@ -128,7 +128,7 @@ IMAGE_OPTIONAL_HEADER = construct.Struct(
     "BaseOfCode" / construct.Int32ul,
     "BaseOfData" / construct.If(this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul),
     "ImageBase" / construct.IfThenElse(
-        this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul, construct.Int64ul
+        this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),
     "SectionAlignment" / construct.Int32ul,
     "FileAlignment" / construct.Int32ul,
@@ -173,16 +173,16 @@ IMAGE_OPTIONAL_HEADER = construct.Struct(
         IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE=0x8000,
     ),
     "SizeOfStackReserve" / construct.IfThenElse(
-        this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul, construct.Int64ul
+        this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),
     "SizeOfStackCommit" / construct.IfThenElse(
-        this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul, construct.Int64ul
+        this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),
     "SizeOfHeapReserve" / construct.IfThenElse(
-        this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul, construct.Int64ul
+        this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),
     "SizeOfHeapCommit" / construct.IfThenElse(
-        this.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC, construct.Int32ul, construct.Int64ul
+        this.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC, construct.Int64ul, construct.Int32ul
     ),
     "LoaderFlags" / construct.Int32ul,
     "NumberOfRvaAndSizes" / construct.Rebuild(construct.Int32ul, construct.len_(this.DataDirectory)),


### PR DESCRIPTION
**Fixed**
* Misspelling of "characteristics" in `IMAGE_IMPORT_DESCRIPTOR`

**Updated**
* Updated `IMAGE_OPTIONAL_HEADER` to support 64-bit and added missing `DllCharacteristics` Flags
* Updated `IMAGE_FILE_HEADER.SizeOfOptionalHeader` to enable leveraging `sizeof()`