### PR TITLE
UnableToParse sub-group bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated `IMAGE_OPTIONAL_HEADER` to support 64-bit and added missing `DllCharacteristics` Flags. (@ddash-ct)
 - Updated `IMAGE_FILE_HEADER.SizeOfOptionalHeader` to enable leveraging `sizeof()`. (@ddash-ct)
+- Changed log messages for file identification and misidentification to update phrasing for parsing groups vs parsing components. (@ddash-ct)
 
 ### Fixed
 - Fixed glob pattern in Techanarchy wrapper. (@cccs-aa)
 - Fixed misspelling of "Characteristics" in `IMAGE_IMPORT_DESCRIPTOR`. (@ddash-ct)
+- Fixed situation in which an `UnableToParse` exception gets consumed within a specific parser group, but none of the 
+    parsers within the group identify the file, and the parent parser places the file back into the queue as though it 
+    were created from the child parsing group. This can result in an infinite processing loop and the solution is to 
+    propagate the `UnableToParse` exception to the parent parser. (@ddash-ct)
     
 ## [3.1.0] - 2020-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed glob pattern in Techanarchy wrapper. (@cccs-aa)
 - Fixed misspelling of "Characteristics" in `IMAGE_IMPORT_DESCRIPTOR`. (@ddash-ct)
-- Fixed situation in which an `UnableToParse` exception gets consumed within a specific parser group, but none of the 
-    parsers within the group identify the file, and the parent parser places the file back into the queue as though it 
-    were created from the child parsing group. This can result in an infinite processing loop and the solution is to 
-    propagate the `UnableToParse` exception to the parent parser. (@ddash-ct)
+- Fixed infinte loop that can be caused due to a sub-parser throwing an `UnableToParse` exception. (@ddash-ct)
     
 ## [3.1.0] - 2020-06-05
 

--- a/mwcp/dispatcher.py
+++ b/mwcp/dispatcher.py
@@ -157,7 +157,11 @@ class Dispatcher(object):
         for parser in self.parsers:
             logger.debug(u"Identifying {} with {!r}.".format(file_object.name, parser))
             if parser.identify(file_object):
-                logger.info(u"File {} identified as {}.".format(file_object.name, parser.DESCRIPTION))
+                if isinstance(parser, Dispatcher):
+                    # Parser is a group, change wording
+                    logger.info(f"File {file_object.name} identified with {parser.DESCRIPTION} parser.")
+                else:
+                    logger.info(f"File {file_object.name} identified as {parser.DESCRIPTION}.")
                 logger.debug(u"{} identified with {!r}".format(file_object.name, parser))
                 yield parser
 
@@ -181,10 +185,17 @@ class Dispatcher(object):
         try:
             parser.parse(file_object, reporter, dispatcher=self)
         except UnableToParse as exception:
-            logger.info(
-                u"File {} was misidentified as {}, due to: ({}) "
-                u"Trying other parsers...".format(file_object.file_name, parser.DESCRIPTION, exception)
-            )
+            if isinstance(parser, Dispatcher):
+                # Parser is a group, change wording
+                logger.info(
+                    f"File {file_object.file_name} was misidentified with {parser.DESCRIPTION} parser, due to: "
+                    f"({exception} Trying other parsers..."
+                )
+            else:
+                logger.info(
+                    f"File {file_object.file_name} was misidentified as {parser.DESCRIPTION}, due to: "
+                    f"({exception} Trying other parsers..."
+                )
             raise
         except Exception:
             logger.exception(u"{} dispatch parser failed".format(parser.name))

--- a/mwcp/dispatcher.py
+++ b/mwcp/dispatcher.py
@@ -189,12 +189,12 @@ class Dispatcher(object):
                 # Parser is a group, change wording
                 logger.info(
                     f"File {file_object.file_name} was misidentified with {parser.DESCRIPTION} parser, due to: "
-                    f"({exception} Trying other parsers..."
+                    f"({exception}) Trying other parsers..."
                 )
             else:
                 logger.info(
                     f"File {file_object.file_name} was misidentified as {parser.DESCRIPTION}, due to: "
-                    f"({exception} Trying other parsers..."
+                    f"({exception}) Trying other parsers..."
                 )
             raise
         except Exception:

--- a/mwcp/dispatcher.py
+++ b/mwcp/dispatcher.py
@@ -219,17 +219,22 @@ class Dispatcher(object):
             identified = False
 
             try:
+                unable_to_parse_error = None
                 # Run any applicable parsers.
                 for parser in self._iter_parsers(file_object):
                     try:
                         self._parse(file_object, parser, reporter)
-                    except UnableToParse:
+                    except UnableToParse as e:
+                        unable_to_parse_error = e
                         continue
                     identified = True
                     if not self.greedy:
                         break
                 if identified:
                     continue
+                elif unable_to_parse_error and dispatcher:
+                    # Pass UnableToParse exception up the chain to notify parent
+                    raise unable_to_parse_error
 
                 # Give it to the parent dispatcher if we can't identify it.
                 if dispatcher:


### PR DESCRIPTION
Identified and fixed situation where an `UnableToParse` exception gets consumed within a specifc parser group, but none of the parsers within the group identify the file, and the parent parser places the file back into the queue as though it were created from the child parsing group. This can result in an infinite processing loop and the solution is to propagate the `UnableToParse` exception to the parent parser.