### PR TITLE
Fix bug in construct.Base64 adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fixed glob pattern in Techanarchy wrapper. (@cccs-aa)
 - Fixed misspelling of "Characteristics" in `IMAGE_IMPORT_DESCRIPTOR`. (@ddash-ct)
 - Fixed infinte loop that can be caused due to a sub-parser throwing an `UnableToParse` exception. (@ddash-ct)
+- Fixed bug in construct.Base64 adapter for build with unicode encoding types. (@ddash-ct)
     
 ## [3.1.0] - 2020-06-05
 

--- a/mwcp/utils/construct/helpers.py
+++ b/mwcp/utils/construct/helpers.py
@@ -345,7 +345,7 @@ class Base64(Adapter):
         obj = custombase64.b64encode(obj, alphabet=self.custom_alpha)
         # Convert to unicode if wrapped subcon expects it.
         if isinstance(self.subcon, StringEncoded):
-            obj = obj.decode(self.subcon.encoding)
+            obj = obj.decode('utf-8')
         return obj
 
     def _decode(self, obj, context, path):

--- a/tests/test_construct.py
+++ b/tests/test_construct.py
@@ -85,3 +85,16 @@ def test_html():
         expected_html_data = fo.read()
 
     assert html_data == expected_html_data
+
+
+def test_base64():
+    """Test the Base64 Adapter with bug associated with unicode encoding on build"""
+    spec = construct.Base64(construct.CString("utf-16le"))
+    data = b'Y\x00W\x00J\x00j\x00Z\x00A\x00=\x00=\x00\x00\x00'
+    assert spec.parse(data) == b"abcd"
+    assert spec.build(b"abcd") == data
+
+    spec = construct.Base64(construct.CString("utf-8"))
+    data = b'YWJjZA==\x00'
+    assert spec.parse(data) == b"abcd"
+    assert spec.build(b"abcd") == data


### PR DESCRIPTION
Bugfix on build for `construct.Base64` adapter associated with using subcon encoding instead of "utf-8"