### PR TITLE
Added source argument to Dispatcher initialization to comply with new method signature

### DIFF
--- a/mwcp/parser.py
+++ b/mwcp/parser.py
@@ -122,7 +122,7 @@ class Parser(object):
         else:
             from mwcp import Dispatcher  # Must import here to avoid cyclic import.
 
-            dispatcher = Dispatcher(cls.name, author=cls.AUTHOR, description=cls.DESCRIPTION, parsers=[cls])
+            dispatcher = Dispatcher(cls.name, cls.source, author=cls.AUTHOR, description=cls.DESCRIPTION, parsers=[cls])
             dispatcher.parse(file_object, reporter)
 
     def run(self):


### PR DESCRIPTION
Commit https://github.com/Defense-Cyber-Crime-Center/DC3-MWCP/commit/e7c9c2eef184ec40feaaa061a20d67e76971878a changed the method signature of the Dispatcher constructor to take a mandatory source argument.
The caller was not adjusted to the new interface in the Parser.parse method, causing a crash.
This PR fixes this issue.