### PR TITLE
Updated test case path for foo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Fixed test case path for `foo` parser, changed to a path which will always exist since input file is irrelevant. (@ddash-ct)
+
+
 ## [3.3.1] - 2021-06-28
 
 ### Added

--- a/mwcp/parsers/tests/foo.json
+++ b/mwcp/parsers/tests/foo.json
@@ -14,7 +14,7 @@
                 "5eb63bbbe01eeed093cb22bb8f5acdc3"
             ]
         ], 
-        "inputfilename": "..\\..\\..\\README.md",
+        "inputfilename": ".\\foo.json",
         "address": [
             "127.0.0.1"
         ]


### PR DESCRIPTION
After installing MWCP, noticed the `foo` test case failed since the target file did not exist. Changed path to something which will always exist since the input file does not matter.