### PR TITLE
Updated mwcp config.load to accept a str or pathlib path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+- config.load now accepts file_path as a string on pathlib.Path (@rhartig-ct)
+  - In 3.6.1 config.load was updated to take pathlib.Path, but mwcp.tools.server still used string
 
 ## [3.6.1] - 2022-03-28
 

--- a/mwcp/config/__init__.py
+++ b/mwcp/config/__init__.py
@@ -73,6 +73,10 @@ class Config(dict):
         if not file_path:
             file_path = self.user_path
 
+        # Convert str file_path to maintain backwards compatibility with previous function definition
+        if isinstance(file_path, str):
+            file_path = pathlib.Path(file_path)
+
         with open(file_path, "r") as fp:
             config = dict(yaml.load(fp))
 


### PR DESCRIPTION
3.6.1 release of mwcp contained a bug while switching from mwcp.config.load: file_path from str to pathlib.Path. 
Passing a string to config.load no longer works due to:
https://github.com/Defense-Cyber-Crime-Center/DC3-MWCP/blob/c2a06ebbf2314a75ec894c0e3650ef9f65f3a7e1/mwcp/config/__init__.py#L80
But mwcp.tools.server still calls config.load with a string.
https://github.com/Defense-Cyber-Crime-Center/DC3-MWCP/blob/c2a06ebbf2314a75ec894c0e3650ef9f65f3a7e1/mwcp/tools/server/server.py#L33