### PR TITLE
Fall back to md5 for blank temporary filenames

### DIFF
--- a/src/mwcp/file_object.py
+++ b/src/mwcp/file_object.py
@@ -523,7 +523,12 @@ class FileObject:
             context = tempfile.TemporaryDirectory(prefix="mwcp_")
 
         with context as tmpdir:
-            temp_file = os.path.join(tmpdir, sanitize_filename(self.name) if self.name else self.md5)
+            # Fall back to the md5 when the name is missing or sanitizes to a
+            # blank/whitespace-only string. Such a name produces an invalid path
+            # that cannot be written (for example a name of all spaces on
+            # Windows). See #51.
+            filename = sanitize_filename(self.name).strip() if self.name else ""
+            temp_file = os.path.join(tmpdir, filename or self.md5)
             if extension and not temp_file.endswith(extension):
                 temp_file += extension
             with open(temp_file, "wb") as fo:

--- a/src/mwcp/tests/test_issues.py
+++ b/src/mwcp/tests/test_issues.py
@@ -89,3 +89,18 @@ SubParser:
     assert residual_files[1].name == "implant.txt"
     assert residual_files[1].description == "Unidentified file"
     assert (output_directory / "3e245_implant.txt").exists()
+
+
+def test_temp_path_with_blank_filename():
+    """
+    Tests bug #51 where a file name that is all whitespace (or otherwise
+    sanitizes to an empty string) produced an invalid temp path that could not
+    be written (for example a name of all spaces on Windows). The md5 should be
+    used as a fallback instead.
+    """
+    import os
+
+    file_object = mwcp.FileObject(b"some data", file_name="     ")
+    with file_object.temp_path() as path:
+        assert os.path.basename(path) == file_object.md5
+        assert os.path.exists(path)

--- a/src/mwcp/tests/test_issues.py
+++ b/src/mwcp/tests/test_issues.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+import os
 import sys
 
 from click.testing import CliRunner
@@ -98,8 +99,6 @@ def test_temp_path_with_blank_filename():
     be written (for example a name of all spaces on Windows). The md5 should be
     used as a fallback instead.
     """
-    import os
-
     file_object = mwcp.FileObject(b"some data", file_name="     ")
     with file_object.temp_path() as path:
         assert os.path.basename(path) == file_object.md5


### PR DESCRIPTION
Fixes #51.

`FileObject.temp_path` built the temp filename as `sanitize_filename(self.name) if self.name else self.md5`. The `if self.name` guard only catches a missing name, so a name that is all whitespace (`"     "`) is treated as present, and `sanitize_filename` returns a whitespace-only string (space is in `VALID_FILENAME_CHARS`). The resulting path cannot be written, for example a trailing-space name on Windows, which is what the issue describes.

The fix strips the sanitized name and falls back to `self.md5` when it is blank, so the md5 fallback that already exists for a missing name now also covers whitespace-only / empty-after-sanitize names. Names that contain real characters are unaffected.

Verified end to end (`mwcp.FileObject(b"...", file_name="     ").temp_path()` now writes to `<md5>` instead of failing; normal names unchanged). Added `test_temp_path_with_blank_filename` to `test_issues.py`; `pytest src/mwcp/tests/test_issues.py` passes.