### PR TITLE
Fix custombase64 encode with an alphabet that omits the padding char

### DIFF
--- a/src/mwcp/tests/test_custombase64.py
+++ b/src/mwcp/tests/test_custombase64.py
@@ -9,6 +9,17 @@ def test_base64():
     assert custombase64.b64decode(b'LSoXMS8BO29dMSj=', custom_alphabet) == b'hello world'
 
 
+def test_base64_alphabet_without_pad_char():
+    # A 64-character alphabet (no explicit padding character) is accepted by
+    # _validate_alphabet, so encoding data that needs padding must not raise.
+    # MWCP appends '=' as the pad in that case.
+    alphabet_64 = b'EFGHQRSTUVWefghijklmnopIJKLMNOPABCDqrstuvwxyXYZabcdz0123456789+/'
+    encoded = custombase64.b64encode(b'hello world', alphabet_64)
+    assert encoded == b'LSoXMS8BO29dMSj='
+    # Round-trips when decoded with the equivalent 65-character alphabet.
+    assert custombase64.b64decode(encoded, alphabet_64 + b'=') == b'hello world'
+
+
 def test_base32():
     custom_alphabet = b'FGHIJQ345RSTUVWXYKLMABCDENOPZ267='
     assert custombase64.b32encode(b'hello world', custom_alphabet) == b'VGLCEPIXJGPC6ZMUUY======'

--- a/src/mwcp/utils/custombase64.py
+++ b/src/mwcp/utils/custombase64.py
@@ -62,7 +62,7 @@ def _code(data, custom_alpha, size, decode, code_func):
         data = data.encode()
     _validate_alphabet(custom_alpha, size)
     if size != 16 and len(custom_alpha) == size:
-        _adjust_pad(custom_alpha, data, decode)
+        custom_alpha = _adjust_pad(custom_alpha, data, decode)
     std_alpha = _STD_ALPHA[size]
 
     if decode:


### PR DESCRIPTION
`_validate_alphabet` accepts a custom alphabet of either `size` or `size + 1` characters, so a 64-character base64 alphabet with no explicit `=` is valid input. When one is passed, `_code` calls `_adjust_pad` to append the padding character, but it discards the return value. The alphabet stays 64 characters and is then handed to `bytes.maketrans` against the 65-character standard table, which raises `maketrans arguments must have same length` for any input that needs padding.

Assigning the `_adjust_pad` result back to `custom_alpha` fixes it. `b64encode(b'hello world', <64-char alphabet>)` now returns `b'LSoXMS8BO29dMSj='` instead of raising, and it round-trips when decoded with the equivalent 65-character alphabet. Alphabets that already include the padding character are unaffected, since `_adjust_pad` only runs when the length equals `size`.

Added `test_base64_alphabet_without_pad_char` to `test_custombase64.py`. `pytest src/mwcp/tests/test_custombase64.py` passes (4 tests).